### PR TITLE
Added reworked version of coco_format_v1 which contains string ids for images and annotations arrays

### DIFF
--- a/gts/coco_format_v3/instances_v3.json
+++ b/gts/coco_format_v3/instances_v3.json
@@ -1,0 +1,5764 @@
+{
+    "licenses": [
+        {
+            "name": "",
+            "id": 0,
+            "url": ""
+        }
+    ],
+    "info": {
+        "contributor": "",
+        "date_created": "",
+        "description": "",
+        "url": "",
+        "version": "",
+        "year": ""
+    },
+    "categories": [
+        {
+            "id": 1,
+            "name": "person",
+            "supercategory": ""
+        },
+        {
+            "id": 2,
+            "name": "cat",
+            "supercategory": ""
+        },
+        {
+            "id": 3,
+            "name": "boat",
+            "supercategory": ""
+        },
+        {
+            "id": 4,
+            "name": "car",
+            "supercategory": ""
+        },
+        {
+            "id": 5,
+            "name": "pottedplant",
+            "supercategory": ""
+        },
+        {
+            "id": 6,
+            "name": "bicycle",
+            "supercategory": ""
+        },
+        {
+            "id": 7,
+            "name": "dog",
+            "supercategory": ""
+        },
+        {
+            "id": 8,
+            "name": "bus",
+            "supercategory": ""
+        },
+        {
+            "id": 9,
+            "name": "motorbike",
+            "supercategory": ""
+        },
+        {
+            "id": 10,
+            "name": "tvmonitor",
+            "supercategory": ""
+        },
+        {
+            "id": 11,
+            "name": "train",
+            "supercategory": ""
+        },
+        {
+            "id": 12,
+            "name": "horse",
+            "supercategory": ""
+        },
+        {
+            "id": 13,
+            "name": "aeroplane",
+            "supercategory": ""
+        },
+        {
+            "id": 14,
+            "name": "sofa",
+            "supercategory": ""
+        },
+        {
+            "id": 15,
+            "name": "chair",
+            "supercategory": ""
+        },
+        {
+            "id": 16,
+            "name": "bird",
+            "supercategory": ""
+        },
+        {
+            "id": 17,
+            "name": "bottle",
+            "supercategory": ""
+        },
+        {
+            "id": 18,
+            "name": "sheep",
+            "supercategory": ""
+        },
+        {
+            "id": 19,
+            "name": "diningtable",
+            "supercategory": ""
+        },
+        {
+            "id": 20,
+            "name": "cow",
+            "supercategory": ""
+        }
+    ],
+    "images": [
+        {
+            "id": "1",
+            "width": 500,
+            "height": 434,
+            "file_name": "2007_001585.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "2",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001583.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "3",
+            "width": 400,
+            "height": 400,
+            "file_name": "2007_001568.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "4",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001558.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "5",
+            "width": 500,
+            "height": 298,
+            "file_name": "2007_001526.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "6",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001487.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "7",
+            "width": 500,
+            "height": 333,
+            "file_name": "2007_001458.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "8",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001457.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "9",
+            "width": 375,
+            "height": 500,
+            "file_name": "2007_001439.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "10",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001430.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "11",
+            "width": 500,
+            "height": 333,
+            "file_name": "2007_001423.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "12",
+            "width": 500,
+            "height": 332,
+            "file_name": "2007_001420.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "13",
+            "width": 500,
+            "height": 328,
+            "file_name": "2007_001416.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "14",
+            "width": 333,
+            "height": 500,
+            "file_name": "2007_001408.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "15",
+            "width": 333,
+            "height": 500,
+            "file_name": "2007_001397.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "16",
+            "width": 500,
+            "height": 366,
+            "file_name": "2007_001377.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "17",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001340.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "18",
+            "width": 500,
+            "height": 333,
+            "file_name": "2007_001321.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "19",
+            "width": 500,
+            "height": 319,
+            "file_name": "2007_001311.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "20",
+            "width": 429,
+            "height": 500,
+            "file_name": "2007_001299.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "21",
+            "width": 500,
+            "height": 309,
+            "file_name": "2007_001289.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "22",
+            "width": 500,
+            "height": 342,
+            "file_name": "2007_001288.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "23",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001284.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "24",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001239.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "25",
+            "width": 387,
+            "height": 500,
+            "file_name": "2007_001225.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "26",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001185.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "27",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001175.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "28",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001154.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "29",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001149.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "30",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001073.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "31",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_001027.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "32",
+            "width": 375,
+            "height": 500,
+            "file_name": "2007_000999.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "33",
+            "width": 500,
+            "height": 353,
+            "file_name": "2007_000925.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "34",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000904.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "35",
+            "width": 500,
+            "height": 334,
+            "file_name": "2007_000876.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "36",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000862.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "37",
+            "width": 375,
+            "height": 500,
+            "file_name": "2007_000847.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "38",
+            "width": 500,
+            "height": 275,
+            "file_name": "2007_000837.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "39",
+            "width": 318,
+            "height": 480,
+            "file_name": "2007_000836.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "40",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000830.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "41",
+            "width": 500,
+            "height": 374,
+            "file_name": "2007_000822.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "42",
+            "width": 334,
+            "height": 500,
+            "file_name": "2007_000807.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "43",
+            "width": 333,
+            "height": 500,
+            "file_name": "2007_000804.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "44",
+            "width": 500,
+            "height": 441,
+            "file_name": "2007_000799.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "45",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000793.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "46",
+            "width": 480,
+            "height": 437,
+            "file_name": "2007_000783.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "47",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000768.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "48",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000762.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "49",
+            "width": 500,
+            "height": 332,
+            "file_name": "2007_000738.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "50",
+            "width": 450,
+            "height": 435,
+            "file_name": "2007_000733.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "51",
+            "width": 375,
+            "height": 500,
+            "file_name": "2007_000727.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "52",
+            "width": 500,
+            "height": 333,
+            "file_name": "2007_000720.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "53",
+            "width": 500,
+            "height": 336,
+            "file_name": "2007_000713.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "54",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000676.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "55",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000664.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "56",
+            "width": 422,
+            "height": 500,
+            "file_name": "2007_000663.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "57",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000661.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "58",
+            "width": 500,
+            "height": 333,
+            "file_name": "2007_000648.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "59",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000645.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "60",
+            "width": 500,
+            "height": 335,
+            "file_name": "2007_000636.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "61",
+            "width": 500,
+            "height": 230,
+            "file_name": "2007_000629.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "62",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000584.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "63",
+            "width": 500,
+            "height": 331,
+            "file_name": "2007_000572.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "64",
+            "width": 500,
+            "height": 370,
+            "file_name": "2007_000559.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "65",
+            "width": 375,
+            "height": 500,
+            "file_name": "2007_000549.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "66",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000529.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "67",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000528.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "68",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000515.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "69",
+            "width": 500,
+            "height": 412,
+            "file_name": "2007_000504.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "70",
+            "width": 500,
+            "height": 334,
+            "file_name": "2007_000491.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "71",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000480.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "72",
+            "width": 375,
+            "height": 500,
+            "file_name": "2007_000464.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "73",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000452.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "74",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000423.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "75",
+            "width": 500,
+            "height": 332,
+            "file_name": "2007_000392.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "76",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000364.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "77",
+            "width": 500,
+            "height": 333,
+            "file_name": "2007_000363.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "78",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000346.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "79",
+            "width": 500,
+            "height": 333,
+            "file_name": "2007_000333.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "80",
+            "width": 500,
+            "height": 333,
+            "file_name": "2007_000332.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "81",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000323.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "82",
+            "width": 333,
+            "height": 500,
+            "file_name": "2007_000272.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "83",
+            "width": 500,
+            "height": 343,
+            "file_name": "2007_000256.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "84",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000250.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "85",
+            "width": 500,
+            "height": 333,
+            "file_name": "2007_000243.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "86",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000241.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "87",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000187.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "88",
+            "width": 500,
+            "height": 332,
+            "file_name": "2007_000175.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "89",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000170.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "90",
+            "width": 334,
+            "height": 500,
+            "file_name": "2007_000129.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "91",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000123.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "92",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000121.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "93",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000068.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "94",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000063.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "95",
+            "width": 500,
+            "height": 333,
+            "file_name": "2007_000061.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "96",
+            "width": 500,
+            "height": 335,
+            "file_name": "2007_000042.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "97",
+            "width": 500,
+            "height": 375,
+            "file_name": "2007_000039.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "98",
+            "width": 500,
+            "height": 366,
+            "file_name": "2007_000033.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "99",
+            "width": 500,
+            "height": 281,
+            "file_name": "2007_000032.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        },
+        {
+            "id": "100",
+            "width": 486,
+            "height": 500,
+            "file_name": "2007_000027.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": 0
+        }
+    ],
+    "annotations": [
+        {
+            "id": "1",
+            "image_id": "1",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 462.0,
+            "bbox": [
+                58.0,
+                158.0,
+                14.0,
+                33.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "2",
+            "image_id": "1",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 31833.0,
+            "bbox": [
+                197.0,
+                115.0,
+                131.0,
+                243.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "3",
+            "image_id": "1",
+            "category_id": 14,
+            "segmentation": [],
+            "area": 67459.0,
+            "bbox": [
+                6.0,
+                180.0,
+                419.0,
+                161.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "4",
+            "image_id": "2",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 58158.0,
+            "bbox": [
+                70.0,
+                16.0,
+                162.0,
+                359.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "5",
+            "image_id": "2",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 23700.0,
+            "bbox": [
+                312.0,
+                45.0,
+                100.0,
+                237.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "6",
+            "image_id": "3",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 131010.0,
+            "bbox": [
+                3.0,
+                42.0,
+                397.0,
+                330.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "7",
+            "image_id": "4",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 67921.0,
+            "bbox": [
+                283.0,
+                15.0,
+                217.0,
+                313.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "8",
+            "image_id": "4",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 77805.0,
+            "bbox": [
+                1.0,
+                56.0,
+                285.0,
+                273.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "9",
+            "image_id": "5",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 33558.0,
+            "bbox": [
+                381.0,
+                15.0,
+                119.0,
+                282.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "10",
+            "image_id": "5",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 25872.0,
+            "bbox": [
+                289.0,
+                33.0,
+                98.0,
+                264.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "11",
+            "image_id": "5",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 27248.0,
+            "bbox": [
+                212.0,
+                35.0,
+                104.0,
+                262.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "12",
+            "image_id": "5",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 25830.0,
+            "bbox": [
+                109.0,
+                51.0,
+                105.0,
+                246.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "13",
+            "image_id": "5",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 31080.0,
+            "bbox": [
+                3.0,
+                18.0,
+                111.0,
+                280.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "14",
+            "image_id": "6",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 1190.0,
+            "bbox": [
+                242.0,
+                117.0,
+                35.0,
+                34.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "15",
+            "image_id": "7",
+            "category_id": 14,
+            "segmentation": [],
+            "area": 50908.0,
+            "bbox": [
+                106.0,
+                121.0,
+                286.0,
+                178.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "16",
+            "image_id": "8",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 11084.0,
+            "bbox": [
+                432.0,
+                212.0,
+                68.0,
+                163.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "17",
+            "image_id": "8",
+            "category_id": 14,
+            "segmentation": [],
+            "area": 30602.0,
+            "bbox": [
+                136.0,
+                121.0,
+                214.0,
+                143.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "18",
+            "image_id": "9",
+            "category_id": 19,
+            "segmentation": [],
+            "area": 65296.0,
+            "bbox": [
+                4.0,
+                324.0,
+                371.0,
+                176.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "19",
+            "image_id": "9",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 4212.0,
+            "bbox": [
+                195.0,
+                282.0,
+                78.0,
+                54.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "20",
+            "image_id": "10",
+            "category_id": 19,
+            "segmentation": [],
+            "area": 26145.0,
+            "bbox": [
+                1.0,
+                269.0,
+                249.0,
+                105.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "21",
+            "image_id": "10",
+            "category_id": 10,
+            "segmentation": [],
+            "area": 6630.0,
+            "bbox": [
+                316.0,
+                1.0,
+                102.0,
+                65.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "22",
+            "image_id": "10",
+            "category_id": 5,
+            "segmentation": [],
+            "area": 2024.0,
+            "bbox": [
+                56.0,
+                174.0,
+                44.0,
+                46.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "23",
+            "image_id": "10",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 33660.0,
+            "bbox": [
+                245.0,
+                154.0,
+                153.0,
+                220.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "24",
+            "image_id": "10",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 18952.0,
+            "bbox": [
+                211.0,
+                146.0,
+                92.0,
+                206.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "25",
+            "image_id": "10",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 17820.0,
+            "bbox": [
+                100.0,
+                154.0,
+                135.0,
+                132.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "26",
+            "image_id": "10",
+            "category_id": 5,
+            "segmentation": [],
+            "area": 11004.0,
+            "bbox": [
+                344.0,
+                83.0,
+                84.0,
+                131.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "27",
+            "image_id": "11",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 71466.0,
+            "bbox": [
+                124.0,
+                56.0,
+                258.0,
+                277.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "28",
+            "image_id": "12",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 15604.0,
+            "bbox": [
+                281.0,
+                80.0,
+                83.0,
+                188.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "29",
+            "image_id": "12",
+            "category_id": 12,
+            "segmentation": [],
+            "area": 23828.0,
+            "bbox": [
+                192.0,
+                109.0,
+                148.0,
+                161.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "30",
+            "image_id": "12",
+            "category_id": 5,
+            "segmentation": [],
+            "area": 10112.0,
+            "bbox": [
+                436.0,
+                148.0,
+                64.0,
+                158.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "31",
+            "image_id": "13",
+            "category_id": 18,
+            "segmentation": [],
+            "area": 27225.0,
+            "bbox": [
+                27.0,
+                13.0,
+                225.0,
+                121.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "32",
+            "image_id": "13",
+            "category_id": 18,
+            "segmentation": [],
+            "area": 11360.0,
+            "bbox": [
+                330.0,
+                26.0,
+                142.0,
+                80.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "33",
+            "image_id": "13",
+            "category_id": 18,
+            "segmentation": [],
+            "area": 46189.0,
+            "bbox": [
+                1.0,
+                185.0,
+                323.0,
+                143.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "34",
+            "image_id": "13",
+            "category_id": 18,
+            "segmentation": [],
+            "area": 17160.0,
+            "bbox": [
+                1.0,
+                106.0,
+                120.0,
+                143.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "35",
+            "image_id": "13",
+            "category_id": 18,
+            "segmentation": [],
+            "area": 20336.0,
+            "bbox": [
+                19.0,
+                71.0,
+                164.0,
+                124.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "36",
+            "image_id": "13",
+            "category_id": 18,
+            "segmentation": [],
+            "area": 22002.0,
+            "bbox": [
+                208.0,
+                78.0,
+                193.0,
+                114.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "37",
+            "image_id": "14",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 13161.0,
+            "bbox": [
+                210.0,
+                1.0,
+                123.0,
+                107.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "38",
+            "image_id": "14",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 48720.0,
+            "bbox": [
+                56.0,
+                107.0,
+                174.0,
+                280.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "39",
+            "image_id": "14",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 12992.0,
+            "bbox": [
+                114.0,
+                245.0,
+                64.0,
+                203.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "40",
+            "image_id": "14",
+            "category_id": 5,
+            "segmentation": [],
+            "area": 8385.0,
+            "bbox": [
+                119.0,
+                1.0,
+                65.0,
+                129.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "41",
+            "image_id": "14",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 69471.0,
+            "bbox": [
+                84.0,
+                87.0,
+                249.0,
+                279.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "42",
+            "image_id": "14",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 2970.0,
+            "bbox": [
+                20.0,
+                68.0,
+                30.0,
+                99.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "43",
+            "image_id": "15",
+            "category_id": 7,
+            "segmentation": [],
+            "area": 12212.0,
+            "bbox": [
+                128.0,
+                121.0,
+                86.0,
+                142.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "44",
+            "image_id": "16",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 3915.0,
+            "bbox": [
+                273.0,
+                163.0,
+                45.0,
+                87.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "45",
+            "image_id": "17",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 42074.0,
+            "bbox": [
+                213.0,
+                48.0,
+                193.0,
+                218.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "46",
+            "image_id": "17",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 62857.0,
+            "bbox": [
+                92.0,
+                111.0,
+                239.0,
+                263.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "47",
+            "image_id": "17",
+            "category_id": 7,
+            "segmentation": [],
+            "area": 15834.0,
+            "bbox": [
+                326.0,
+                284.0,
+                174.0,
+                91.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "48",
+            "image_id": "17",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 23970.0,
+            "bbox": [
+                150.0,
+                140.0,
+                102.0,
+                235.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "49",
+            "image_id": "18",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 106925.0,
+            "bbox": [
+                1.0,
+                98.0,
+                455.0,
+                235.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "50",
+            "image_id": "19",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 4232.0,
+            "bbox": [
+                334.0,
+                128.0,
+                46.0,
+                92.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "51",
+            "image_id": "19",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 2244.0,
+            "bbox": [
+                432.0,
+                118.0,
+                33.0,
+                68.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "52",
+            "image_id": "19",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 6588.0,
+            "bbox": [
+                333.0,
+                79.0,
+                54.0,
+                122.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "53",
+            "image_id": "19",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 1550.0,
+            "bbox": [
+                465.0,
+                104.0,
+                25.0,
+                62.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "54",
+            "image_id": "19",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 19448.0,
+            "bbox": [
+                187.0,
+                106.0,
+                104.0,
+                187.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "55",
+            "image_id": "19",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 29784.0,
+            "bbox": [
+                27.0,
+                61.0,
+                136.0,
+                219.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "56",
+            "image_id": "19",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 3552.0,
+            "bbox": [
+                431.0,
+                75.0,
+                37.0,
+                96.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "57",
+            "image_id": "19",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 2784.0,
+            "bbox": [
+                463.0,
+                67.0,
+                32.0,
+                87.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "58",
+            "image_id": "19",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 26702.0,
+            "bbox": [
+                12.0,
+                161.0,
+                169.0,
+                158.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "59",
+            "image_id": "19",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 16637.0,
+            "bbox": [
+                177.0,
+                188.0,
+                127.0,
+                131.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "60",
+            "image_id": "20",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 18144.0,
+            "bbox": [
+                211.0,
+                240.0,
+                108.0,
+                168.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "61",
+            "image_id": "20",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 73340.0,
+            "bbox": [
+                39.0,
+                26.0,
+                190.0,
+                386.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "62",
+            "image_id": "20",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 19260.0,
+            "bbox": [
+                318.0,
+                221.0,
+                90.0,
+                214.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "63",
+            "image_id": "21",
+            "category_id": 16,
+            "segmentation": [],
+            "area": 17820.0,
+            "bbox": [
+                157.0,
+                98.0,
+                198.0,
+                90.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "64",
+            "image_id": "22",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 47614.0,
+            "bbox": [
+                68.0,
+                76.0,
+                358.0,
+                133.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "65",
+            "image_id": "22",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 5040.0,
+            "bbox": [
+                196.0,
+                272.0,
+                120.0,
+                42.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "66",
+            "image_id": "22",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 6300.0,
+            "bbox": [
+                357.0,
+                272.0,
+                140.0,
+                45.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "67",
+            "image_id": "23",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 25200.0,
+            "bbox": [
+                135.0,
+                123.0,
+                100.0,
+                252.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "68",
+            "image_id": "23",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 1421.0,
+            "bbox": [
+                419.0,
+                90.0,
+                29.0,
+                49.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "69",
+            "image_id": "23",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 32625.0,
+            "bbox": [
+                1.0,
+                114.0,
+                125.0,
+                261.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "70",
+            "image_id": "23",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 51939.0,
+            "bbox": [
+                301.0,
+                114.0,
+                199.0,
+                261.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "71",
+            "image_id": "23",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 36450.0,
+            "bbox": [
+                276.0,
+                117.0,
+                150.0,
+                243.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "72",
+            "image_id": "23",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 26082.0,
+            "bbox": [
+                238.0,
+                115.0,
+                138.0,
+                189.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "73",
+            "image_id": "24",
+            "category_id": 7,
+            "segmentation": [],
+            "area": 21200.0,
+            "bbox": [
+                108.0,
+                60.0,
+                212.0,
+                100.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "74",
+            "image_id": "24",
+            "category_id": 7,
+            "segmentation": [],
+            "area": 36261.0,
+            "bbox": [
+                228.0,
+                138.0,
+                153.0,
+                237.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "75",
+            "image_id": "24",
+            "category_id": 7,
+            "segmentation": [],
+            "area": 35784.0,
+            "bbox": [
+                118.0,
+                94.0,
+                168.0,
+                213.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "76",
+            "image_id": "25",
+            "category_id": 7,
+            "segmentation": [],
+            "area": 41006.0,
+            "bbox": [
+                100.0,
+                212.0,
+                203.0,
+                202.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "77",
+            "image_id": "26",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 62667.0,
+            "bbox": [
+                78.0,
+                78.0,
+                211.0,
+                297.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "78",
+            "image_id": "26",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 5856.0,
+            "bbox": [
+                452.0,
+                131.0,
+                48.0,
+                122.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "79",
+            "image_id": "26",
+            "category_id": 19,
+            "segmentation": [],
+            "area": 44992.0,
+            "bbox": [
+                204.0,
+                223.0,
+                296.0,
+                152.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "80",
+            "image_id": "26",
+            "category_id": 2,
+            "segmentation": [],
+            "area": 11408.0,
+            "bbox": [
+                197.0,
+                199.0,
+                92.0,
+                124.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "81",
+            "image_id": "27",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 43648.0,
+            "bbox": [
+                119.0,
+                153.0,
+                248.0,
+                176.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "82",
+            "image_id": "27",
+            "category_id": 10,
+            "segmentation": [],
+            "area": 6497.0,
+            "bbox": [
+                360.0,
+                114.0,
+                89.0,
+                73.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "83",
+            "image_id": "27",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 6039.0,
+            "bbox": [
+                157.0,
+                169.0,
+                99.0,
+                61.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "84",
+            "image_id": "28",
+            "category_id": 14,
+            "segmentation": [],
+            "area": 24566.0,
+            "bbox": [
+                1.0,
+                233.0,
+                173.0,
+                142.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "85",
+            "image_id": "28",
+            "category_id": 5,
+            "segmentation": [],
+            "area": 1628.0,
+            "bbox": [
+                134.0,
+                230.0,
+                37.0,
+                44.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "86",
+            "image_id": "29",
+            "category_id": 14,
+            "segmentation": [],
+            "area": 41820.0,
+            "bbox": [
+                148.0,
+                138.0,
+                255.0,
+                164.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "87",
+            "image_id": "29",
+            "category_id": 10,
+            "segmentation": [],
+            "area": 4828.0,
+            "bbox": [
+                75.0,
+                85.0,
+                71.0,
+                68.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "88",
+            "image_id": "29",
+            "category_id": 5,
+            "segmentation": [],
+            "area": 51888.0,
+            "bbox": [
+                1.0,
+                7.0,
+                141.0,
+                368.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "89",
+            "image_id": "30",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 7104.0,
+            "bbox": [
+                276.0,
+                159.0,
+                74.0,
+                96.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "90",
+            "image_id": "30",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 6580.0,
+            "bbox": [
+                55.0,
+                178.0,
+                94.0,
+                70.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "91",
+            "image_id": "30",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 2535.0,
+            "bbox": [
+                135.0,
+                176.0,
+                39.0,
+                65.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "92",
+            "image_id": "30",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 4565.0,
+            "bbox": [
+                227.0,
+                153.0,
+                55.0,
+                83.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "93",
+            "image_id": "30",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 8624.0,
+            "bbox": [
+                327.0,
+                152.0,
+                98.0,
+                88.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "94",
+            "image_id": "30",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 5214.0,
+            "bbox": [
+                421.0,
+                161.0,
+                79.0,
+                66.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "95",
+            "image_id": "31",
+            "category_id": 10,
+            "segmentation": [],
+            "area": 4032.0,
+            "bbox": [
+                1.0,
+                244.0,
+                42.0,
+                96.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "96",
+            "image_id": "31",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 2232.0,
+            "bbox": [
+                58.0,
+                156.0,
+                36.0,
+                62.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "97",
+            "image_id": "31",
+            "category_id": 14,
+            "segmentation": [],
+            "area": 10395.0,
+            "bbox": [
+                401.0,
+                270.0,
+                99.0,
+                105.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "98",
+            "image_id": "31",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 931.0,
+            "bbox": [
+                329.0,
+                174.0,
+                19.0,
+                49.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "99",
+            "image_id": "31",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 9768.0,
+            "bbox": [
+                263.0,
+                218.0,
+                88.0,
+                111.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "100",
+            "image_id": "31",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 5150.0,
+            "bbox": [
+                256.0,
+                189.0,
+                50.0,
+                103.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "101",
+            "image_id": "31",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 5049.0,
+            "bbox": [
+                203.0,
+                174.0,
+                51.0,
+                99.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "102",
+            "image_id": "32",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 4928.0,
+            "bbox": [
+                233.0,
+                317.0,
+                56.0,
+                88.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "103",
+            "image_id": "32",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 134552.0,
+            "bbox": [
+                2.0,
+                16.0,
+                278.0,
+                484.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "104",
+            "image_id": "33",
+            "category_id": 18,
+            "segmentation": [],
+            "area": 34428.0,
+            "bbox": [
+                309.0,
+                105.0,
+                151.0,
+                228.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "105",
+            "image_id": "33",
+            "category_id": 18,
+            "segmentation": [],
+            "area": 45254.0,
+            "bbox": [
+                29.0,
+                101.0,
+                187.0,
+                242.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "106",
+            "image_id": "34",
+            "category_id": 12,
+            "segmentation": [],
+            "area": 49248.0,
+            "bbox": [
+                1.0,
+                213.0,
+                304.0,
+                162.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "107",
+            "image_id": "34",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 18500.0,
+            "bbox": [
+                17.0,
+                113.0,
+                148.0,
+                125.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "108",
+            "image_id": "34",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 9696.0,
+            "bbox": [
+                237.0,
+                167.0,
+                101.0,
+                96.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "109",
+            "image_id": "35",
+            "category_id": 2,
+            "segmentation": [],
+            "area": 77182.0,
+            "bbox": [
+                117.0,
+                31.0,
+                259.0,
+                298.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "110",
+            "image_id": "35",
+            "category_id": 2,
+            "segmentation": [],
+            "area": 16166.0,
+            "bbox": [
+                261.0,
+                14.0,
+                137.0,
+                118.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "111",
+            "image_id": "36",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 900.0,
+            "bbox": [
+                304.0,
+                142.0,
+                50.0,
+                18.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "112",
+            "image_id": "36",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 260.0,
+            "bbox": [
+                305.0,
+                131.0,
+                13.0,
+                20.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "113",
+            "image_id": "37",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 91415.0,
+            "bbox": [
+                61.0,
+                111.0,
+                235.0,
+                389.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "114",
+            "image_id": "37",
+            "category_id": 19,
+            "segmentation": [],
+            "area": 45747.0,
+            "bbox": [
+                1.0,
+                279.0,
+                207.0,
+                221.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "115",
+            "image_id": "38",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 9776.0,
+            "bbox": [
+                261.0,
+                65.0,
+                104.0,
+                94.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "116",
+            "image_id": "39",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 30690.0,
+            "bbox": [
+                69.0,
+                99.0,
+                155.0,
+                198.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "117",
+            "image_id": "39",
+            "category_id": 12,
+            "segmentation": [],
+            "area": 37240.0,
+            "bbox": [
+                93.0,
+                162.0,
+                133.0,
+                280.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "118",
+            "image_id": "40",
+            "category_id": 19,
+            "segmentation": [],
+            "area": 42864.0,
+            "bbox": [
+                124.0,
+                182.0,
+                228.0,
+                188.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "119",
+            "image_id": "40",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 16786.0,
+            "bbox": [
+                150.0,
+                221.0,
+                109.0,
+                154.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "120",
+            "image_id": "40",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 14016.0,
+            "bbox": [
+                252.0,
+                201.0,
+                96.0,
+                146.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "121",
+            "image_id": "40",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 4964.0,
+            "bbox": [
+                250.0,
+                175.0,
+                68.0,
+                73.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "122",
+            "image_id": "41",
+            "category_id": 9,
+            "segmentation": [],
+            "area": 18910.0,
+            "bbox": [
+                231.0,
+                168.0,
+                122.0,
+                155.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "123",
+            "image_id": "41",
+            "category_id": 9,
+            "segmentation": [],
+            "area": 23892.0,
+            "bbox": [
+                98.0,
+                165.0,
+                132.0,
+                181.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "124",
+            "image_id": "42",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 77854.0,
+            "bbox": [
+                34.0,
+                31.0,
+                166.0,
+                469.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "125",
+            "image_id": "43",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 3599.0,
+            "bbox": [
+                94.0,
+                243.0,
+                59.0,
+                61.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "126",
+            "image_id": "43",
+            "category_id": 14,
+            "segmentation": [],
+            "area": 28905.0,
+            "bbox": [
+                191.0,
+                265.0,
+                141.0,
+                205.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "127",
+            "image_id": "43",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 13066.0,
+            "bbox": [
+                32.0,
+                352.0,
+                94.0,
+                139.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "128",
+            "image_id": "44",
+            "category_id": 12,
+            "segmentation": [],
+            "area": 169290.0,
+            "bbox": [
+                95.0,
+                23.0,
+                405.0,
+                418.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "129",
+            "image_id": "44",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 58320.0,
+            "bbox": [
+                230.0,
+                225.0,
+                270.0,
+                216.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "130",
+            "image_id": "45",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 1738.0,
+            "bbox": [
+                273.0,
+                103.0,
+                22.0,
+                79.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "131",
+            "image_id": "45",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 936.0,
+            "bbox": [
+                96.0,
+                107.0,
+                18.0,
+                52.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "132",
+            "image_id": "45",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 969.0,
+            "bbox": [
+                65.0,
+                110.0,
+                19.0,
+                51.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "133",
+            "image_id": "45",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 12480.0,
+            "bbox": [
+                402.0,
+                67.0,
+                65.0,
+                192.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "134",
+            "image_id": "45",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 1278.0,
+            "bbox": [
+                218.0,
+                107.0,
+                18.0,
+                71.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "135",
+            "image_id": "45",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 2001.0,
+            "bbox": [
+                241.0,
+                111.0,
+                29.0,
+                69.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "136",
+            "image_id": "45",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 2241.0,
+            "bbox": [
+                289.0,
+                100.0,
+                27.0,
+                83.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "137",
+            "image_id": "45",
+            "category_id": 8,
+            "segmentation": [],
+            "area": 2695.0,
+            "bbox": [
+                2.0,
+                80.0,
+                49.0,
+                55.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "138",
+            "image_id": "45",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 19080.0,
+            "bbox": [
+                151.0,
+                160.0,
+                159.0,
+                120.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "139",
+            "image_id": "45",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 18360.0,
+            "bbox": [
+                100.0,
+                78.0,
+                90.0,
+                204.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "140",
+            "image_id": "46",
+            "category_id": 12,
+            "segmentation": [],
+            "area": 101661.0,
+            "bbox": [
+                112.0,
+                100.0,
+                329.0,
+                309.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "141",
+            "image_id": "46",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 25048.0,
+            "bbox": [
+                201.0,
+                57.0,
+                124.0,
+                202.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "142",
+            "image_id": "47",
+            "category_id": 8,
+            "segmentation": [],
+            "area": 95424.0,
+            "bbox": [
+                33.0,
+                46.0,
+                336.0,
+                284.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "143",
+            "image_id": "47",
+            "category_id": 8,
+            "segmentation": [],
+            "area": 19080.0,
+            "bbox": [
+                369.0,
+                103.0,
+                106.0,
+                180.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "144",
+            "image_id": "48",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 27600.0,
+            "bbox": [
+                4.0,
+                22.0,
+                120.0,
+                230.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "145",
+            "image_id": "48",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 987.0,
+            "bbox": [
+                199.0,
+                140.0,
+                21.0,
+                47.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "146",
+            "image_id": "48",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 11808.0,
+            "bbox": [
+                143.0,
+                127.0,
+                123.0,
+                96.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "147",
+            "image_id": "48",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 3060.0,
+            "bbox": [
+                342.0,
+                142.0,
+                51.0,
+                60.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "148",
+            "image_id": "48",
+            "category_id": 19,
+            "segmentation": [],
+            "area": 92814.0,
+            "bbox": [
+                1.0,
+                189.0,
+                499.0,
+                186.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "149",
+            "image_id": "48",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 13509.0,
+            "bbox": [
+                3.0,
+                249.0,
+                171.0,
+                79.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "150",
+            "image_id": "48",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 19847.0,
+            "bbox": [
+                29.0,
+                152.0,
+                89.0,
+                223.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "151",
+            "image_id": "48",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 23600.0,
+            "bbox": [
+                382.0,
+                61.0,
+                118.0,
+                200.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "152",
+            "image_id": "49",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 54945.0,
+            "bbox": [
+                1.0,
+                124.0,
+                495.0,
+                111.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "153",
+            "image_id": "50",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 80550.0,
+            "bbox": [
+                48.0,
+                25.0,
+                225.0,
+                358.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "154",
+            "image_id": "50",
+            "category_id": 9,
+            "segmentation": [],
+            "area": 80730.0,
+            "bbox": [
+                103.0,
+                201.0,
+                345.0,
+                234.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "155",
+            "image_id": "51",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 4785.0,
+            "bbox": [
+                2.0,
+                380.0,
+                87.0,
+                55.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "156",
+            "image_id": "51",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 1222.0,
+            "bbox": [
+                113.0,
+                138.0,
+                47.0,
+                26.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "157",
+            "image_id": "51",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 902.0,
+            "bbox": [
+                49.0,
+                367.0,
+                41.0,
+                22.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "158",
+            "image_id": "51",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 1071.0,
+            "bbox": [
+                354.0,
+                363.0,
+                21.0,
+                51.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "159",
+            "image_id": "51",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 1474.0,
+            "bbox": [
+                319.0,
+                357.0,
+                22.0,
+                67.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "160",
+            "image_id": "51",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 2050.0,
+            "bbox": [
+                333.0,
+                356.0,
+                25.0,
+                82.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "161",
+            "image_id": "51",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 969.0,
+            "bbox": [
+                272.0,
+                369.0,
+                51.0,
+                19.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "162",
+            "image_id": "51",
+            "category_id": 8,
+            "segmentation": [],
+            "area": 20792.0,
+            "bbox": [
+                89.0,
+                323.0,
+                184.0,
+                113.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "163",
+            "image_id": "52",
+            "category_id": 7,
+            "segmentation": [],
+            "area": 12760.0,
+            "bbox": [
+                217.0,
+                118.0,
+                88.0,
+                145.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "164",
+            "image_id": "53",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 25056.0,
+            "bbox": [
+                80.0,
+                168.0,
+                174.0,
+                144.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "165",
+            "image_id": "53",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 31392.0,
+            "bbox": [
+                184.0,
+                160.0,
+                288.0,
+                109.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "166",
+            "image_id": "54",
+            "category_id": 18,
+            "segmentation": [],
+            "area": 72688.0,
+            "bbox": [
+                59.0,
+                94.0,
+                413.0,
+                176.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "167",
+            "image_id": "55",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 102202.0,
+            "bbox": [
+                51.0,
+                2.0,
+                274.0,
+                373.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "168",
+            "image_id": "56",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 1960.0,
+            "bbox": [
+                373.0,
+                68.0,
+                49.0,
+                40.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "169",
+            "image_id": "56",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 5152.0,
+            "bbox": [
+                376.0,
+                98.0,
+                46.0,
+                112.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "170",
+            "image_id": "56",
+            "category_id": 8,
+            "segmentation": [],
+            "area": 188325.0,
+            "bbox": [
+                12.0,
+                2.0,
+                405.0,
+                465.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "171",
+            "image_id": "56",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 3080.0,
+            "bbox": [
+                7.0,
+                39.0,
+                56.0,
+                55.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "172",
+            "image_id": "56",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 1740.0,
+            "bbox": [
+                362.0,
+                24.0,
+                60.0,
+                29.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "173",
+            "image_id": "56",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 2070.0,
+            "bbox": [
+                376.0,
+                36.0,
+                46.0,
+                45.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "174",
+            "image_id": "57",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 1748.0,
+            "bbox": [
+                133.0,
+                159.0,
+                46.0,
+                38.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "175",
+            "image_id": "57",
+            "category_id": 14,
+            "segmentation": [],
+            "area": 21412.0,
+            "bbox": [
+                119.0,
+                177.0,
+                212.0,
+                101.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "176",
+            "image_id": "57",
+            "category_id": 5,
+            "segmentation": [],
+            "area": 11235.0,
+            "bbox": [
+                65.0,
+                90.0,
+                105.0,
+                107.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "177",
+            "image_id": "58",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 240.0,
+            "bbox": [
+                394.0,
+                199.0,
+                10.0,
+                24.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "178",
+            "image_id": "58",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 240.0,
+            "bbox": [
+                434.0,
+                196.0,
+                10.0,
+                24.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "179",
+            "image_id": "58",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 225.0,
+            "bbox": [
+                443.0,
+                195.0,
+                9.0,
+                25.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "180",
+            "image_id": "58",
+            "category_id": 8,
+            "segmentation": [],
+            "area": 49572.0,
+            "bbox": [
+                29.0,
+                113.0,
+                324.0,
+                153.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "181",
+            "image_id": "58",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 15476.0,
+            "bbox": [
+                328.0,
+                86.0,
+                146.0,
+                106.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "182",
+            "image_id": "58",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 572.0,
+            "bbox": [
+                2.0,
+                213.0,
+                26.0,
+                22.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "183",
+            "image_id": "58",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 252.0,
+            "bbox": [
+                424.0,
+                199.0,
+                12.0,
+                21.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "184",
+            "image_id": "59",
+            "category_id": 16,
+            "segmentation": [],
+            "area": 119720.0,
+            "bbox": [
+                135.0,
+                46.0,
+                365.0,
+                328.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "185",
+            "image_id": "59",
+            "category_id": 16,
+            "segmentation": [],
+            "area": 55189.0,
+            "bbox": [
+                124.0,
+                146.0,
+                241.0,
+                229.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "186",
+            "image_id": "60",
+            "category_id": 11,
+            "segmentation": [],
+            "area": 63852.0,
+            "bbox": [
+                79.0,
+                96.0,
+                313.0,
+                204.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "187",
+            "image_id": "61",
+            "category_id": 11,
+            "segmentation": [],
+            "area": 46600.0,
+            "bbox": [
+                34.0,
+                84.0,
+                466.0,
+                100.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "188",
+            "image_id": "61",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 480.0,
+            "bbox": [
+                87.0,
+                100.0,
+                20.0,
+                24.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "189",
+            "image_id": "62",
+            "category_id": 14,
+            "segmentation": [],
+            "area": 26052.0,
+            "bbox": [
+                344.0,
+                207.0,
+                156.0,
+                167.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "190",
+            "image_id": "62",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 91936.0,
+            "bbox": [
+                31.0,
+                74.0,
+                338.0,
+                272.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "191",
+            "image_id": "63",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 35534.0,
+            "bbox": [
+                8.0,
+                134.0,
+                218.0,
+                163.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "192",
+            "image_id": "63",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 35802.0,
+            "bbox": [
+                1.0,
+                178.0,
+                234.0,
+                153.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "193",
+            "image_id": "64",
+            "category_id": 10,
+            "segmentation": [],
+            "area": 45365.0,
+            "bbox": [
+                160.0,
+                26.0,
+                211.0,
+                215.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "194",
+            "image_id": "64",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 4472.0,
+            "bbox": [
+                36.0,
+                250.0,
+                43.0,
+                104.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "195",
+            "image_id": "65",
+            "category_id": 2,
+            "segmentation": [],
+            "area": 153000.0,
+            "bbox": [
+                1.0,
+                49.0,
+                340.0,
+                450.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "196",
+            "image_id": "66",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 22470.0,
+            "bbox": [
+                290.0,
+                143.0,
+                210.0,
+                107.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "197",
+            "image_id": "66",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 702.0,
+            "bbox": [
+                422.0,
+                237.0,
+                39.0,
+                18.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "198",
+            "image_id": "67",
+            "category_id": 2,
+            "segmentation": [],
+            "area": 47190.0,
+            "bbox": [
+                124.0,
+                68.0,
+                195.0,
+                242.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "199",
+            "image_id": "68",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 3666.0,
+            "bbox": [
+                1.0,
+                199.0,
+                39.0,
+                94.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "200",
+            "image_id": "68",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 5432.0,
+            "bbox": [
+                1.0,
+                85.0,
+                28.0,
+                194.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "201",
+            "image_id": "68",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 4002.0,
+            "bbox": [
+                64.0,
+                164.0,
+                87.0,
+                46.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "202",
+            "image_id": "68",
+            "category_id": 4,
+            "segmentation": [],
+            "area": 1287.0,
+            "bbox": [
+                147.0,
+                167.0,
+                39.0,
+                33.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "203",
+            "image_id": "69",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 48336.0,
+            "bbox": [
+                341.0,
+                102.0,
+                159.0,
+                304.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "204",
+            "image_id": "69",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 3827.0,
+            "bbox": [
+                36.0,
+                34.0,
+                43.0,
+                89.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "205",
+            "image_id": "69",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 2584.0,
+            "bbox": [
+                2.0,
+                44.0,
+                34.0,
+                76.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "206",
+            "image_id": "69",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 264.0,
+            "bbox": [
+                29.0,
+                42.0,
+                12.0,
+                22.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "207",
+            "image_id": "70",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 151724.0,
+            "bbox": [
+                2.0,
+                2.0,
+                457.0,
+                332.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "208",
+            "image_id": "71",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 22311.0,
+            "bbox": [
+                5.0,
+                172.0,
+                111.0,
+                201.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "209",
+            "image_id": "71",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 23712.0,
+            "bbox": [
+                114.0,
+                165.0,
+                114.0,
+                208.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "210",
+            "image_id": "71",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 26838.0,
+            "bbox": [
+                293.0,
+                162.0,
+                126.0,
+                213.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "211",
+            "image_id": "71",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 124388.0,
+            "bbox": [
+                2.0,
+                68.0,
+                484.0,
+                257.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "212",
+            "image_id": "72",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 8990.0,
+            "bbox": [
+                71.0,
+                252.0,
+                145.0,
+                62.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "213",
+            "image_id": "72",
+            "category_id": 20,
+            "segmentation": [],
+            "area": 17019.0,
+            "bbox": [
+                58.0,
+                202.0,
+                183.0,
+                93.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "214",
+            "image_id": "73",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 3744.0,
+            "bbox": [
+                474.0,
+                140.0,
+                26.0,
+                144.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "215",
+            "image_id": "73",
+            "category_id": 14,
+            "segmentation": [],
+            "area": 53165.0,
+            "bbox": [
+                50.0,
+                121.0,
+                245.0,
+                217.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "216",
+            "image_id": "74",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 20962.0,
+            "bbox": [
+                367.0,
+                92.0,
+                94.0,
+                223.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "217",
+            "image_id": "74",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 13206.0,
+            "bbox": [
+                51.0,
+                80.0,
+                71.0,
+                186.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "218",
+            "image_id": "75",
+            "category_id": 12,
+            "segmentation": [],
+            "area": 58140.0,
+            "bbox": [
+                100.0,
+                96.0,
+                255.0,
+                228.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "219",
+            "image_id": "75",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 12232.0,
+            "bbox": [
+                198.0,
+                58.0,
+                88.0,
+                139.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "220",
+            "image_id": "76",
+            "category_id": 9,
+            "segmentation": [],
+            "area": 21204.0,
+            "bbox": [
+                318.0,
+                37.0,
+                171.0,
+                124.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "221",
+            "image_id": "76",
+            "category_id": 9,
+            "segmentation": [],
+            "area": 116000.0,
+            "bbox": [
+                54.0,
+                25.0,
+                400.0,
+                290.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "222",
+            "image_id": "76",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 11481.0,
+            "bbox": [
+                369.0,
+                1.0,
+                89.0,
+                129.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "223",
+            "image_id": "77",
+            "category_id": 16,
+            "segmentation": [],
+            "area": 71529.0,
+            "bbox": [
+                161.0,
+                122.0,
+                339.0,
+                211.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "224",
+            "image_id": "77",
+            "category_id": 16,
+            "segmentation": [],
+            "area": 36064.0,
+            "bbox": [
+                59.0,
+                15.0,
+                161.0,
+                224.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "225",
+            "image_id": "78",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 106920.0,
+            "bbox": [
+                137.0,
+                78.0,
+                360.0,
+                297.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "226",
+            "image_id": "78",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 1950.0,
+            "bbox": [
+                72.0,
+                209.0,
+                39.0,
+                50.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "227",
+            "image_id": "78",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 25016.0,
+            "bbox": [
+                124.0,
+                107.0,
+                106.0,
+                236.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "228",
+            "image_id": "78",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 1800.0,
+            "bbox": [
+                89.0,
+                202.0,
+                40.0,
+                45.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "229",
+            "image_id": "79",
+            "category_id": 11,
+            "segmentation": [],
+            "area": 84546.0,
+            "bbox": [
+                1.0,
+                39.0,
+                366.0,
+                231.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "230",
+            "image_id": "80",
+            "category_id": 12,
+            "segmentation": [],
+            "area": 48972.0,
+            "bbox": [
+                54.0,
+                50.0,
+                231.0,
+                212.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "231",
+            "image_id": "81",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 82956.0,
+            "bbox": [
+                277.0,
+                3.0,
+                223.0,
+                372.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "232",
+            "image_id": "81",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 108996.0,
+            "bbox": [
+                12.0,
+                3.0,
+                293.0,
+                372.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "233",
+            "image_id": "82",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 119691.0,
+            "bbox": [
+                25.0,
+                71.0,
+                279.0,
+                429.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "234",
+            "image_id": "83",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 65688.0,
+            "bbox": [
+                8.0,
+                96.0,
+                483.0,
+                136.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "235",
+            "image_id": "84",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 9169.0,
+            "bbox": [
+                97.0,
+                124.0,
+                53.0,
+                173.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "236",
+            "image_id": "84",
+            "category_id": 19,
+            "segmentation": [],
+            "area": 96965.0,
+            "bbox": [
+                1.0,
+                170.0,
+                473.0,
+                205.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "237",
+            "image_id": "85",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 6138.0,
+            "bbox": [
+                181.0,
+                127.0,
+                93.0,
+                66.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "238",
+            "image_id": "86",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 8466.0,
+            "bbox": [
+                246.0,
+                134.0,
+                102.0,
+                83.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "239",
+            "image_id": "86",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 8528.0,
+            "bbox": [
+                60.0,
+                109.0,
+                82.0,
+                104.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "240",
+            "image_id": "86",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 13968.0,
+            "bbox": [
+                356.0,
+                183.0,
+                144.0,
+                97.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "241",
+            "image_id": "87",
+            "category_id": 10,
+            "segmentation": [],
+            "area": 57599.0,
+            "bbox": [
+                1.0,
+                95.0,
+                239.0,
+                241.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "242",
+            "image_id": "88",
+            "category_id": 18,
+            "segmentation": [],
+            "area": 93378.0,
+            "bbox": [
+                25.0,
+                34.0,
+                394.0,
+                237.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "243",
+            "image_id": "89",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 4600.0,
+            "bbox": [
+                3.0,
+                91.0,
+                40.0,
+                115.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "244",
+            "image_id": "89",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 157208.0,
+            "bbox": [
+                4.0,
+                28.0,
+                457.0,
+                344.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "245",
+            "image_id": "89",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 646.0,
+            "bbox": [
+                426.0,
+                157.0,
+                17.0,
+                38.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "246",
+            "image_id": "89",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 1624.0,
+            "bbox": [
+                324.0,
+                148.0,
+                28.0,
+                58.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "247",
+            "image_id": "89",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 2144.0,
+            "bbox": [
+                41.0,
+                114.0,
+                32.0,
+                67.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "248",
+            "image_id": "89",
+            "category_id": 17,
+            "segmentation": [],
+            "area": 1430.0,
+            "bbox": [
+                87.0,
+                100.0,
+                22.0,
+                65.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "249",
+            "image_id": "90",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 55130.0,
+            "bbox": [
+                70.0,
+                202.0,
+                185.0,
+                298.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "250",
+            "image_id": "90",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 38376.0,
+            "bbox": [
+                252.0,
+                19.0,
+                82.0,
+                468.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "251",
+            "image_id": "90",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 91278.0,
+            "bbox": [
+                74.0,
+                1.0,
+                198.0,
+                461.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "252",
+            "image_id": "90",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 23530.0,
+            "bbox": [
+                1.0,
+                1.0,
+                65.0,
+                362.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "253",
+            "image_id": "90",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 19272.0,
+            "bbox": [
+                1.0,
+                144.0,
+                66.0,
+                292.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "254",
+            "image_id": "90",
+            "category_id": 6,
+            "segmentation": [],
+            "area": 21414.0,
+            "bbox": [
+                251.0,
+                242.0,
+                83.0,
+                258.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "255",
+            "image_id": "91",
+            "category_id": 11,
+            "segmentation": [],
+            "area": 112098.0,
+            "bbox": [
+                1.0,
+                26.0,
+                357.0,
+                314.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "256",
+            "image_id": "92",
+            "category_id": 10,
+            "segmentation": [],
+            "area": 53536.0,
+            "bbox": [
+                251.0,
+                28.0,
+                224.0,
+                239.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "257",
+            "image_id": "92",
+            "category_id": 10,
+            "segmentation": [],
+            "area": 56105.0,
+            "bbox": [
+                22.0,
+                28.0,
+                229.0,
+                245.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "258",
+            "image_id": "93",
+            "category_id": 16,
+            "segmentation": [],
+            "area": 78870.0,
+            "bbox": [
+                27.0,
+                45.0,
+                239.0,
+                330.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "259",
+            "image_id": "94",
+            "category_id": 7,
+            "segmentation": [],
+            "area": 40960.0,
+            "bbox": [
+                123.0,
+                115.0,
+                256.0,
+                160.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "260",
+            "image_id": "94",
+            "category_id": 15,
+            "segmentation": [],
+            "area": 132022.0,
+            "bbox": [
+                75.0,
+                1.0,
+                353.0,
+                374.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "261",
+            "image_id": "95",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 3686.0,
+            "bbox": [
+                184.0,
+                214.0,
+                97.0,
+                38.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "262",
+            "image_id": "95",
+            "category_id": 3,
+            "segmentation": [],
+            "area": 43684.0,
+            "bbox": [
+                274.0,
+                11.0,
+                163.0,
+                268.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "263",
+            "image_id": "96",
+            "category_id": 11,
+            "segmentation": [],
+            "area": 61542.0,
+            "bbox": [
+                1.0,
+                36.0,
+                234.0,
+                263.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "264",
+            "image_id": "96",
+            "category_id": 11,
+            "segmentation": [],
+            "area": 62331.0,
+            "bbox": [
+                263.0,
+                32.0,
+                237.0,
+                263.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "265",
+            "image_id": "97",
+            "category_id": 10,
+            "segmentation": [],
+            "area": 35720.0,
+            "bbox": [
+                156.0,
+                89.0,
+                188.0,
+                190.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "266",
+            "image_id": "98",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 3010.0,
+            "bbox": [
+                325.0,
+                188.0,
+                86.0,
+                35.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "267",
+            "image_id": "98",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 76440.0,
+            "bbox": [
+                9.0,
+                107.0,
+                490.0,
+                156.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "268",
+            "image_id": "98",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 1586.0,
+            "bbox": [
+                421.0,
+                200.0,
+                61.0,
+                26.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "269",
+            "image_id": "99",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 882.0,
+            "bbox": [
+                26.0,
+                189.0,
+                18.0,
+                49.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "270",
+            "image_id": "99",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 2240.0,
+            "bbox": [
+                133.0,
+                88.0,
+                64.0,
+                35.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "271",
+            "image_id": "99",
+            "category_id": 13,
+            "segmentation": [],
+            "area": 28455.0,
+            "bbox": [
+                104.0,
+                78.0,
+                271.0,
+                105.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "272",
+            "image_id": "99",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 882.0,
+            "bbox": [
+                195.0,
+                180.0,
+                18.0,
+                49.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        },
+        {
+            "id": "273",
+            "image_id": "100",
+            "category_id": 1,
+            "segmentation": [],
+            "area": 43750.0,
+            "bbox": [
+                174.0,
+                101.0,
+                175.0,
+                250.0
+            ],
+            "iscrowd": 0,
+            "attributes": {
+                "occluded": false
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Hi @laclouis5,

as requested here https://github.com/laclouis5/globox/pull/13, this PR contains a new variant of the default coco file. I'll attempt to update the PR on the main repo to reflect the change of test data.